### PR TITLE
9888 - Disabled writing ignored errors for Xlsx Worksheets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com)
 and this project adheres to [Semantic Versioning](https://semver.org).
 
+## 2024-10-16 - 3.3.0.2
+
+### Added
+
+- Nothing
+
+### Changed
+
+- Disabled writing ignored errors for Xlsx Worksheets
+
+### Deprecated
+
+- Nothing
+
+### Removed
+
+- Nothing
+
+### Fixed
+
+- Nothing
+
 ## 2024-10-02 - 3.3.0.1
 
 ### Added

--- a/src/PhpSpreadsheet/Writer/Xlsx/Worksheet.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/Worksheet.php
@@ -22,6 +22,8 @@ use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet as PhpspreadsheetWorksheet;
 
 class Worksheet extends WriterPart
 {
+    private bool $writeIgnoredErrors = false;
+
     private string $numberStoredAsText = '';
 
     private string $formula = '';
@@ -142,7 +144,9 @@ class Worksheet extends WriterPart
         $this->writeAlternateContent($objWriter, $worksheet);
 
         // IgnoredErrors
-        $this->writeIgnoredErrors($objWriter);
+        if ($this->writeIgnoredErrors) {
+            $this->writeIgnoredErrors($objWriter);
+        }
 
         // BackgroundImage must come after ignored, before table
         $this->writeBackgroundImage($objWriter, $worksheet);


### PR DESCRIPTION
 + Disabled writing ignored errors for Xlsx Worksheets

This is:

- [x] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [ ] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [ ] Code style is respected
- [ ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

To avoid a breaking issue with some legacy Xlsx files.
